### PR TITLE
主页添加跳转链接，服务器列表增加了地区选择以及玩家名称搜索

### DIFF
--- a/src/components/home/index.tsx
+++ b/src/components/home/index.tsx
@@ -1,5 +1,7 @@
 import m from 'mithril';
 
+import 'styles/home.scss';
+
 export default class implements m.ClassComponent {
   data = '';
 
@@ -11,7 +13,33 @@ export default class implements m.ClassComponent {
     return (
       <div class="container">
         <div class="content">
-          <h1>建设中</h1>
+          <section class="section is-large">
+            <div class="serverlist">
+              <a class="button" href="/#?/browser">
+                <h1 class="title">服务器浏览器</h1>
+              </a>
+              <h2 class="subtitle">
+                搜索 Teeworlds 在线服务器！
+              </h2>
+            </div>
+            <div class="wiki">
+              <a class="button" href="https://wiki.teeworlds.cn/">
+                <h1 class="title">中文维基百科</h1>
+              </a>
+              <h2 class="subtitle">
+                原生模式/mod介绍，服务器开设指南，闯关指南...
+              </h2>
+            </div>
+          </section>
+          <section class="section is-medium">
+            <div class="link">
+              <h1 class="title">中文社区</h1>
+              <a class="button" href="">QQ (2群)</a>
+              <a class="button" href="https://www.kaiheila.cn/app/invite/pNXyP8">开黑啦</a>
+              <a class="button" href="https://discord.gg/dqwuHEq">Discord</a>
+              <a class="button" href="https://t.me/teeworldscn">Telegram</a>
+            </div>
+          </section>
         </div>
       </div>
     );

--- a/src/components/home/index.tsx
+++ b/src/components/home/index.tsx
@@ -34,7 +34,6 @@ export default class implements m.ClassComponent {
           <section class="section is-medium">
             <div class="link">
               <h1 class="title">中文社区</h1>
-              <a class="button" href="">QQ (2群)</a>
               <a class="button" href="https://www.kaiheila.cn/app/invite/pNXyP8">开黑啦</a>
               <a class="button" href="https://discord.gg/dqwuHEq">Discord</a>
               <a class="button" href="https://t.me/teeworldscn">Telegram</a>

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -1,0 +1,21 @@
+.content h1 {
+	margin-bottom: 1em;
+}
+
+.content h2:not(:first-child) {
+    margin-top: 0.5em;
+}
+
+.button:hover {
+	border-top-color: #00000000;
+	border-left-color: #00000000;
+	border-right-color: #00000000;
+}
+
+.wiki {
+	padding: 30px 0;
+}
+
+.link a {
+	margin-right: 20px;
+}


### PR DESCRIPTION
Home
添加 服务器列表 跳转按钮
添加 中文维基百科 跳转按钮
添加 中文社区 开黑啦、Discord、Telegram平台

Browser
增加 地区 选择
支持 玩家名称 搜索